### PR TITLE
Drop error-on-warn test of Emacs 24.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-elc: compile
 test-compilation: clean-elc
 	${CASK} exec ${EMACS} -Q -batch -L ./ -eval \
 	"(progn \
-	   (when (version<= \"24.3\" emacs-version) \
+	   (when (version<= \"24.4\" emacs-version) \
 	     (setq byte-compile-error-on-warn t)) \
 	   (batch-byte-compile))" ./*.el
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ test-el: clean-elc
 test-elc: compile
 	${CASK} exec ert-runner ./sloth-test.elc
 
+# Ert on Emacs 24.3 or older makes many unused value warnings.
+# That is the reason why only Emacs 24.4 or newer versions are tested with
+# byte-compile-error-on-warn = t.
 test-compilation: clean-elc
 	${CASK} exec ${EMACS} -Q -batch -L ./ -eval \
 	"(progn \


### PR DESCRIPTION
I'll test the error-on-warn test only on Emacs 24.4 or newer because ert on Emacs 24.3 or older makes many unused value warnings like this:

> In toplevel form:
> sloth-test.el:37:18:Warning: value returned from (car value-2) is unused
> sloth-test.el:37:18:Warning: value returned from (car value-7) is unused
> sloth-test.el:37:18:Warning: value returned from (car value-12) is unused
> sloth-test.el:47:14:Warning: value returned from (car value-22) is unused
> sloth-test.el:47:14:Warning: value returned from (car value-27) is unused
> sloth-test.el:52:14:Warning: value returned from (car value-37) is unused
> sloth-test.el:56:14:Warning: value returned from (car value-47) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-57) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-62) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-67) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-72) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-77) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-82) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-87) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-92) is unused
> sloth-test.el:67:13:Warning: value returned from (car value-97) is unused
> sloth-test.el:92:15:Warning: value returned from (car value-107) is unused
> sloth-test.el:102:12:Warning: value returned from (car value-117) is unused
> sloth-test.el:102:12:Warning: value returned from (car value-122) is unused
> sloth-test.el:102:12:Warning: value returned from (car value-127) is unused
> Wrote /home/travis/build/HKey/sloth/sloth-test.elc
> 
> Job #4.3 - HKey/sloth - Travis CI
> https://travis-ci.org/HKey/sloth/jobs/88953036
